### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ const { uniqueId, pick } = require('lodash');
 
 class ClientSOQL extends Client {
   constructor(options = {}) {
-    super();
+    super({ client: 'soql' });
     if (options.connection) {
       if (options.connection instanceof Connection) {
         this._connection = options.connection;


### PR DESCRIPTION
Address [this](https://github.com/tgriesser/knex/blob/master/src/client.js#L39-L47) deprecation warning. `this.dialect` will be deprecated in future releases. To avoid breaking backward compatibility I didn't remove `get dialect () { return 'soql' }`.